### PR TITLE
May 22 updates - Link reference updated

### DIFF
--- a/app/views/v5/plants/pinus-pinea.html
+++ b/app/views/v5/plants/pinus-pinea.html
@@ -319,7 +319,7 @@ href: "javascript:window.history.back()"
         </tr>
         <tr class="govuk-table__row">
 
-          <td class="govuk-table__cell"><a class="govuk-link" rel="noreferrer noopener" target="_blank" href="/{{version}}/pests/ips-typographus">Ips typographus</a>
+          <td class="govuk-table__cell"><a class="govuk-link" href="/{{version}}/pests/ips-typographus">Ips typographus</a>
           </td>
           <td class="govuk-table__cell">Eight-spined engraver, Eight-toothed spruce bark beetle, Larger eight-toothed
             European spruce bark beetle, Spruce bark beetle</td>


### PR DESCRIPTION
1. On pinus pinea details page, pest page was opening in the new tab. It has been fixed now.